### PR TITLE
Python27 support removal

### DIFF
--- a/pyopenfec/aggregates.py
+++ b/pyopenfec/aggregates.py
@@ -2,7 +2,6 @@ from . import utils
 
 
 class CommitteeTotals(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.all_loans_received = None
         self.all_other_loans = None
@@ -91,32 +90,25 @@ class CommitteeTotals(utils.PyOpenFecApiPaginatedClass):
         self.transfers_to_other_authorized_committee = None
 
         date_fields = {
-            'coverage_start_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            'coverage_end_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            }
+            "coverage_start_date": "%Y-%m-%dT%H:%M:%S+00:00",
+            "coverage_end_date": "%Y-%m-%dT%H:%M:%S+00:00",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{cid} totals ({c} cycle, {csd}-{ced})".format(
-            cid=self.committee_id,
-            c=self.cycle,
-            csd=self.coverage_start_date,
-            ced=self.coverage_end_date
-        ))
-
     def __str__(self):
-        return repr("{cid} totals ({c} cycle, {csd}-{ced})".format(
-            cid=self.committee_id,
-            c=self.cycle,
-            csd=self.coverage_start_date,
-            ced=self.coverage_end_date
-        ))
+        return repr(
+            "{cid} totals ({c} cycle, {csd}-{ced})".format(
+                cid=self.committee_id,
+                c=self.cycle,
+                csd=self.coverage_start_date,
+                ced=self.coverage_end_date,
+            )
+        )
 
 
 class AggregateScheduleAByContributor(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.committee_id = None
         self.contributor_id = None
@@ -131,15 +123,14 @@ class AggregateScheduleAByContributor(utils.PyOpenFecApiPaginatedClass):
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_a/by_contributor'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_a/by_contributor"
 
         for record in super(AggregateScheduleAByContributor, cls).fetch(**kwargs):
             yield record
 
 
 class AggregateScheduleABySize(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.committee_id = None
         self.count = None
@@ -152,15 +143,14 @@ class AggregateScheduleABySize(utils.PyOpenFecApiPaginatedClass):
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_a/by_size'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_a/by_size"
 
         for record in super(AggregateScheduleABySize, cls).fetch(**kwargs):
             yield record
 
 
 class AggregateScheduleAByState(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.committee_id = None
         self.count = None
@@ -173,15 +163,14 @@ class AggregateScheduleAByState(utils.PyOpenFecApiPaginatedClass):
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_a/by_state'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_a/by_state"
 
         for record in super(AggregateScheduleAByState, cls).fetch(**kwargs):
             yield record
 
 
 class AggregateScheduleAByZip(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.committee_id = None
         self.count = None
@@ -194,15 +183,14 @@ class AggregateScheduleAByZip(utils.PyOpenFecApiPaginatedClass):
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_a/by_zip'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_a/by_zip"
 
         for record in super(AggregateScheduleAByZip, cls).fetch(**kwargs):
             yield record
 
 
 class AggregateScheduleEByCandidate(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.candidate_id = None
         self.candidate_name = None
@@ -218,8 +206,8 @@ class AggregateScheduleEByCandidate(utils.PyOpenFecApiPaginatedClass):
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_e/by_candidate'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_e/by_candidate"
 
         for record in super(AggregateScheduleEByCandidate, cls).fetch(**kwargs):
             yield record

--- a/pyopenfec/candidate.py
+++ b/pyopenfec/candidate.py
@@ -6,7 +6,6 @@ from .aggregates import AggregateScheduleEByCandidate
 
 
 class Candidate(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
-
     def __init__(self, **kwargs):
         self.active_through = None
         self.address_city = None
@@ -41,28 +40,23 @@ class Candidate(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
         self._committees = None
 
         date_fields = {
-            'first_file_date': '%Y-%m-%d',
-            'last_f2_date': '%Y-%m-%d',
-            'last_file_date': '%Y-%m-%d',
-            'load_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            }
+            "first_file_date": "%Y-%m-%d",
+            "last_f2_date": "%Y-%m-%d",
+            "last_file_date": "%Y-%m-%d",
+            "load_date": "%Y-%m-%dT%H:%M:%S+00:00",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{name} {id}".format(name=self.name,
-                                            id=self.candidate_id))
-
     def __str__(self):
-        return repr("{name} {id}".format(name=self.name,
-                                         id=self.candidate_id))
+        return repr("{name} {id}".format(name=self.name, id=self.candidate_id))
 
     @property
     def history(self):
         if self._history is None:
             self._history = {}
-            resource_path = 'candidate/{cid}/history'.format(cid=self.candidate_id)
+            resource_path = "candidate/{cid}/history".format(cid=self.candidate_id)
             for hp in CandidateHistoryPeriod.fetch(resource=resource_path):
                 self._history[hp.two_year_period] = hp
         return self._history
@@ -84,19 +78,17 @@ class Candidate(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
     @utils.default_empty_list
     def aggregated_independent_expenditures(self, **kwargs):
         independent_expenditures = AggregateScheduleEByCandidate.fetch(
-            candidate_id=self.candidate_id, **kwargs)
+            candidate_id=self.candidate_id, **kwargs
+        )
         return [f for f in independent_expenditures]
 
     def principal_committee(self, cycle):
         return Committee.fetch_one(
-            candidate_id=self.candidate_id,
-            cycle=cycle,
-            designation='P',
-            )
+            candidate_id=self.candidate_id, cycle=cycle, designation="P"
+        )
 
 
 class CandidateHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.active_through = None
         self.address_city = None
@@ -129,23 +121,18 @@ class CandidateHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
         self.two_year_period = None
 
         date_fields = {
-            'first_file_date': '%Y-%m-%d',
-            'last_f2_date': '%Y-%m-%d',
-            'last_file_date': '%Y-%m-%d',
-            'load_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            }
+            "first_file_date": "%Y-%m-%d",
+            "last_f2_date": "%Y-%m-%d",
+            "last_file_date": "%Y-%m-%d",
+            "load_date": "%Y-%m-%dT%H:%M:%S+00:00",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{name} [{cand_id}] ({period})".format(
-            name=self.name,
-            cand_id=self.candidate_id,
-            period=self.two_year_period))
-
     def __str__(self):
-        return repr("{name} [{cand_id}] ({period})".format(
-            name=self.name,
-            cand_id=self.candidate_id,
-            period=self.two_year_period))
+        return repr(
+            "{name} [{cand_id}] ({period})".format(
+                name=self.name, cand_id=self.candidate_id, period=self.two_year_period
+            )
+        )

--- a/pyopenfec/committee.py
+++ b/pyopenfec/committee.py
@@ -1,14 +1,17 @@
 from . import utils
 from .filing import Filing
 from .report import Report
-from .aggregates import (CommitteeTotals, AggregateScheduleAByZip,
-                         AggregateScheduleAByState, AggregateScheduleABySize,
-                         AggregateScheduleAByContributor)
+from .aggregates import (
+    CommitteeTotals,
+    AggregateScheduleAByZip,
+    AggregateScheduleAByState,
+    AggregateScheduleABySize,
+    AggregateScheduleAByContributor,
+)
 from .transaction import ScheduleATransaction, ScheduleBTransaction
 
 
 class Committee(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
-
     def __init__(self, **kwargs):
         self.candidate_ids = None
         self.city = None
@@ -70,27 +73,22 @@ class Committee(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
         self._totals = None
 
         date_fields = {
-            'first_file_date': '%Y-%m-%d',
-            'last_f1_date': '%Y-%m-%d',
-            'last_file_date': '%Y-%m-%d',
-            }
+            "first_file_date": "%Y-%m-%d",
+            "last_f1_date": "%Y-%m-%d",
+            "last_file_date": "%Y-%m-%d",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{name} {id}".format(name=self.name,
-                                            id=self.committee_id))
-
     def __str__(self):
-        return repr("{name} {id}".format(name=self.name,
-                                         id=self.committee_id))
+        return repr("{name} {id}".format(name=self.name, id=self.committee_id))
 
     @property
     def history(self):
         if self._history is None:
             self._history = {}
-            resource_path = 'committee/{cid}/history'.format(cid=self.committee_id)
+            resource_path = "committee/{cid}/history".format(cid=self.committee_id)
             for hp in CommitteeHistoryPeriod.fetch(resource=resource_path):
                 self._history[hp.cycle] = hp
         return self._history
@@ -99,7 +97,7 @@ class Committee(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
     def totals(self):
         if self._totals is None:
             self._totals = {}
-            resource_path = 'committee/{cid}/totals'.format(cid=self.committee_id)
+            resource_path = "committee/{cid}/totals".format(cid=self.committee_id)
             for ct in CommitteeTotals.fetch(resource=resource_path):
                 self._totals[ct.cycle] = ct
         return self._totals
@@ -114,78 +112,96 @@ class Committee(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
 
     @utils.default_empty_list
     def select_reports(self, **kwargs):
-        resource_path = 'committee/{cid}/reports'.format(cid=self.committee_id)
-        return [r for r in Report.fetch(resource=resource_path,
-                                        committee_id=self.committee_id,
-                                        **kwargs)]
+        resource_path = "committee/{cid}/reports".format(cid=self.committee_id)
+        return [
+            r
+            for r in Report.fetch(
+                resource=resource_path, committee_id=self.committee_id, **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_reports(self):
-        resource_path = 'committee/{cid}/reports'.format(cid=self.committee_id)
-        return [r for r in Report.fetch(resource=resource_path,
-                                        committee_id=self.committee_id)]
+        resource_path = "committee/{cid}/reports".format(cid=self.committee_id)
+        return [
+            r
+            for r in Report.fetch(
+                resource=resource_path, committee_id=self.committee_id
+            )
+        ]
 
     @utils.default_empty_list
     def select_receipts(self, **kwargs):
-        return [t for t in ScheduleATransaction.fetch(
-            committee_id=self.committee_id, **kwargs)]
+        return [
+            t
+            for t in ScheduleATransaction.fetch(
+                committee_id=self.committee_id, **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_receipts(self):
-        return [t for t in ScheduleATransaction.fetch(
-            committee_id=self.committee_id)]
+        return [t for t in ScheduleATransaction.fetch(committee_id=self.committee_id)]
 
     @utils.default_empty_list
     def select_contributions(self, **kwargs):
-        return [t for t in ScheduleATransaction.fetch(
-            contributor_id=self.committee_id, **kwargs)]
+        return [
+            t
+            for t in ScheduleATransaction.fetch(
+                contributor_id=self.committee_id, **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_contributions(self):
-        return [t for t in ScheduleATransaction.fetch(
-            contributor_id=self.committee_id)]
+        return [t for t in ScheduleATransaction.fetch(contributor_id=self.committee_id)]
 
     @utils.default_empty_list
     def select_disbursements(self, **kwargs):
-        return [t for t in ScheduleBTransaction.fetch(
-            committee_id=self.committee_id, **kwargs)]
+        return [
+            t
+            for t in ScheduleBTransaction.fetch(
+                committee_id=self.committee_id, **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_disbursements(self):
-        return [r for r in ScheduleBTransaction.fetch(
-            committee_id=self.committee_id)]
+        return [r for r in ScheduleBTransaction.fetch(committee_id=self.committee_id)]
 
     @utils.default_empty_list
     def total_receipts_by_state(self, **kwargs):
-        resource = 'committee/{cid}/schedules/schedule_a/by_state'.format(
-            cid=self.committee_id)
-        return [a for a in AggregateScheduleAByState.fetch(
-            resource=resource, **kwargs)]
+        resource = "committee/{cid}/schedules/schedule_a/by_state".format(
+            cid=self.committee_id
+        )
+        return [a for a in AggregateScheduleAByState.fetch(resource=resource, **kwargs)]
 
     @utils.default_empty_list
     def total_receipts_by_size(self, **kwargs):
-        resource = 'committee/{cid}/schedules/schedule_a/by_size'.format(
-            cid=self.committee_id)
-        return [a for a in AggregateScheduleABySize.fetch(
-            resource=resource, **kwargs)]
+        resource = "committee/{cid}/schedules/schedule_a/by_size".format(
+            cid=self.committee_id
+        )
+        return [a for a in AggregateScheduleABySize.fetch(resource=resource, **kwargs)]
 
     @utils.default_empty_list
     def total_receipts_by_zip(self, **kwargs):
-        resource = 'committee/{cid}/schedules/schedule_a/by_zip'.format(
-            cid=self.committee_id)
-        return [a for a in AggregateScheduleAByZip.fetch(
-            resource=resource, **kwargs)]
+        resource = "committee/{cid}/schedules/schedule_a/by_zip".format(
+            cid=self.committee_id
+        )
+        return [a for a in AggregateScheduleAByZip.fetch(resource=resource, **kwargs)]
 
     @utils.default_empty_list
     def total_receipts_by_contributor(self, **kwargs):
-        resource = 'committee/{cid}/schedules/schedule_a/by_contributor'.format(
-            cid=self.committee_id)
-        return [a for a in AggregateScheduleAByContributor.fetch(
-            resource=resource, **kwargs)]
+        resource = "committee/{cid}/schedules/schedule_a/by_contributor".format(
+            cid=self.committee_id
+        )
+        return [
+            a
+            for a in AggregateScheduleAByContributor.fetch(resource=resource, **kwargs)
+        ]
 
 
 class CommitteeHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.city = None
         self.committee_id = None
@@ -211,14 +227,9 @@ class CommitteeHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def __unicode__(self):
-        return unicode("{name} [{comm_id}] ({period})".format(
-            name=self.name,
-            comm_id=self.committee_id,
-            period=self.two_year_period))
-
     def __str__(self):
-        return repr("{name} [{comm_id}] ({period})".format(
-            name=self.name,
-            comm_id=self.committee_id,
-            period=self.two_year_period))
+        return repr(
+            "{name} [{comm_id}] ({period})".format(
+                name=self.name, comm_id=self.committee_id, period=self.two_year_period
+            )
+        )

--- a/pyopenfec/filing.py
+++ b/pyopenfec/filing.py
@@ -3,7 +3,6 @@ from .transaction import ScheduleATransaction, ScheduleBTransaction
 
 
 class Filing(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.amendment_chain = None
         self.amendment_indicator = None
@@ -62,49 +61,61 @@ class Filing(utils.PyOpenFecApiPaginatedClass):
         self.update_date = None
 
         date_fields = {
-            'coverage_end_date': '%Y-%m-%dT%H:%M:%S',
-            'coverage_start_date': '%Y-%m-%dT%H:%M:%S',
-            'receipt_date': '%Y-%m-%dT%H:%M:%S',
-            'update_date': '%Y-%m-%dT%H:%M:%S',
-            }
+            "coverage_end_date": "%Y-%m-%dT%H:%M:%S",
+            "coverage_start_date": "%Y-%m-%dT%H:%M:%S",
+            "receipt_date": "%Y-%m-%dT%H:%M:%S",
+            "update_date": "%Y-%m-%dT%H:%M:%S",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{cid}'s #{fn} Form {ft} ({rtf})".format(fn=self.file_number,
-                                                                cid=self.committee_id,
-                                                                ft=self.form_type,
-                                                                rtf=self.report_type_full))
-
     def __str__(self):
-        return "{cid}'s #{fn} Form {ft} ({rtf})".format(fn=self.file_number,
-                                                        cid=self.committee_id,
-                                                        ft=self.form_type,
-                                                        rtf=self.report_type_full)
+        return "{cid}'s #{fn} Form {ft} ({rtf})".format(
+            fn=self.file_number,
+            cid=self.committee_id,
+            ft=self.form_type,
+            rtf=self.report_type_full,
+        )
 
     @utils.default_empty_list
     def select_receipts(self, **kwargs):
-        return [t for t in ScheduleATransaction.fetch(
-            min_image_number=self.beginning_image_number,
-            max_image_number=self.ending_image_number,
-            **kwargs)]
+        return [
+            t
+            for t in ScheduleATransaction.fetch(
+                min_image_number=self.beginning_image_number,
+                max_image_number=self.ending_image_number,
+                **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_receipts(self):
-        return [t for t in ScheduleATransaction.fetch(
-            min_image_number=self.beginning_image_number,
-            max_image_number=self.ending_image_number)]
+        return [
+            t
+            for t in ScheduleATransaction.fetch(
+                min_image_number=self.beginning_image_number,
+                max_image_number=self.ending_image_number,
+            )
+        ]
 
     @utils.default_empty_list
     def select_disbursements(self, **kwargs):
-        return [t for t in ScheduleBTransaction.fetch(
-            min_image_number=self.beginning_image_number,
-            max_image_number=self.ending_image_number,
-            **kwargs)]
+        return [
+            t
+            for t in ScheduleBTransaction.fetch(
+                min_image_number=self.beginning_image_number,
+                max_image_number=self.ending_image_number,
+                **kwargs
+            )
+        ]
 
     @utils.default_empty_list
     def all_disbursements(self):
-        return [r for r in ScheduleBTransaction.fetch(
-            min_image_number=self.beginning_image_number,
-            max_image_number=self.ending_image_number)]
+        return [
+            r
+            for r in ScheduleBTransaction.fetch(
+                min_image_number=self.beginning_image_number,
+                max_image_number=self.ending_image_number,
+            )
+        ]

--- a/pyopenfec/report.py
+++ b/pyopenfec/report.py
@@ -2,7 +2,6 @@ from . import utils
 
 
 class Report(utils.PyOpenFecApiPaginatedClass):
-
     def __init__(self, **kwargs):
         self.aggregate_amount_personal_contributions_general = None
         self.aggregate_contributions_personal_funds_primary = None
@@ -188,28 +187,21 @@ class Report(utils.PyOpenFecApiPaginatedClass):
         self.transfers_to_other_authorized_committee_ytd = None
 
         date_fields = {
-            'coverage_end_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            'coverage_start_date': '%Y-%m-%dT%H:%M:%S+00:00',
-            'receipt_date': '%Y-%m-%dT%H:%M:%S',
-            }
+            "coverage_end_date": "%Y-%m-%dT%H:%M:%S+00:00",
+            "coverage_start_date": "%Y-%m-%dT%H:%M:%S+00:00",
+            "receipt_date": "%Y-%m-%dT%H:%M:%S",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
-    def __unicode__(self):
-        return unicode("{cid} {rtf} ({c} cycle, {csd}-{ced})".format(
-            cid=self.committee_id,
-            rtf=self.report_type_full,
-            c=self.cycle,
-            csd=self.coverage_start_date,
-            ced=self.coverage_end_date
-        ))
-
     def __str__(self):
-        return repr("{cid} {rtf} ({c} cycle, {csd}-{ced})".format(
-            cid=self.committee_id,
-            rtf=self.report_type_full,
-            c=self.cycle,
-            csd=self.coverage_start_date,
-            ced=self.coverage_end_date
-        ))
+        return repr(
+            "{cid} {rtf} ({c} cycle, {csd}-{ced})".format(
+                cid=self.committee_id,
+                rtf=self.report_type_full,
+                c=self.cycle,
+                csd=self.coverage_start_date,
+                ced=self.coverage_end_date,
+            )
+        )

--- a/pyopenfec/transaction.py
+++ b/pyopenfec/transaction.py
@@ -2,7 +2,6 @@ from . import utils
 
 
 class ScheduleATransaction(utils.PyOpenFecApiIndexedClass):
-
     def __init__(self, **kwargs):
         self.amendment_indicator = None
         self.amendment_indicator_desc = None
@@ -86,41 +85,34 @@ class ScheduleATransaction(utils.PyOpenFecApiIndexedClass):
         self.unused_contbr_id = None
 
         date_fields = {
-            'contribution_receipt_date': '%Y-%m-%dT%H:%M:%S',
-            'load_date': '%Y-%m-%dT%H:%M:%S.%f+00:00',
-            'timestamp': '%Y-%m-%dT%H:%M:%S.%f+00:00',
-            }
+            "contribution_receipt_date": "%Y-%m-%dT%H:%M:%S",
+            "load_date": "%Y-%m-%dT%H:%M:%S.%f+00:00",
+            "timestamp": "%Y-%m-%dT%H:%M:%S.%f+00:00",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_a'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_a"
 
         for record in super(ScheduleATransaction, cls).fetch(**kwargs):
             yield record
 
-    def __unicode__(self):
-        return unicode("{cid} receipt: {fn} ({t}, {d})".format(
-            cid=self.committee_id,
-            fn=self.file_number,
-            t=self.tran_id,
-            d=self.receipt_date
-        ))
-
     def __str__(self):
-        return repr("{cid} receipt: {fn} ({t}, {d})".format(
-            cid=self.committee_id,
-            fn=self.file_number,
-            t=self.tran_id,
-            d=self.receipt_date
-        ))
+        return repr(
+            "{cid} receipt: {fn} ({t}, {d})".format(
+                cid=self.committee_id,
+                fn=self.file_number,
+                t=self.tran_id,
+                d=self.receipt_date,
+            )
+        )
 
 
 class ScheduleBTransaction(utils.PyOpenFecApiIndexedClass):
-
     def __init__(self, **kwargs):
         self.amendment_indicator = None
         self.amendment_indicator_desc = None
@@ -204,33 +196,27 @@ class ScheduleBTransaction(utils.PyOpenFecApiIndexedClass):
         self.unused_contbr_id = None
 
         date_fields = {
-            'disbursement_date': '%Y-%m-%dT%H:%M:%S',
-            'load_date': '%Y-%m-%dT%H:%M:%S.%f+00:00',
-            }
+            "disbursement_date": "%Y-%m-%dT%H:%M:%S",
+            "load_date": "%Y-%m-%dT%H:%M:%S.%f+00:00",
+        }
 
         for k, v in kwargs.items():
             utils.set_instance_attr(self, k, v, date_fields)
 
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' not in kwargs:
-            kwargs['resource'] = 'schedules/schedule_b'
+        if "resource" not in kwargs:
+            kwargs["resource"] = "schedules/schedule_b"
 
         for record in super(ScheduleBTransaction, cls).fetch(**kwargs):
             yield record
 
-    def __unicode__(self):
-        return unicode("{cid} receipt: {fn} ({t}, {d})".format(
-            cid=self.committee_id,
-            fn=self.file_number,
-            t=self.tran_id,
-            d=self.disbursement_date
-        ))
-
     def __str__(self):
-        return repr("{cid} receipt: {fn} ({t}, {d})".format(
-            cid=self.committee_id,
-            fn=self.file_number,
-            t=self.tran_id,
-            d=self.disbursement_date
-        ))
+        return repr(
+            "{cid} receipt: {fn} ({t}, {d})".format(
+                cid=self.committee_id,
+                fn=self.file_number,
+                t=self.tran_id,
+                d=self.disbursement_date,
+            )
+        )

--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -12,24 +12,23 @@ if six.PY2:
     from exceptions import Exception, NotImplementedError, TypeError
 
 
-API_KEY = os.environ.get('OPENFEC_API_KEY', None)
-BASE_URL = 'https://api.open.fec.gov'
-VERSION = '/v1'
+API_KEY = os.environ.get("OPENFEC_API_KEY", None)
+BASE_URL = "https://api.open.fec.gov"
+VERSION = "/v1"
 
-eastern = timezone('US/Eastern')
+eastern = timezone("US/Eastern")
+
 
 class PyOpenFecException(Exception):
     """
     An exception from the PyOpenFec API.
     """
+
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return repr(self.value)
-
-    def __unicode__(self):
-        return unicode(self.value)
 
     def __repr__(self):
         return repr(self.value)
@@ -39,6 +38,7 @@ class PyOpenFecApiClass(object):
     """
     Universal class for PyOpenFec API classes to inherit from.
     """
+
     ratelimit_remaining = 1000
     wait_time = 0.5
 
@@ -50,18 +50,18 @@ class PyOpenFecApiClass(object):
 
     @classmethod
     def count(cls, **kwargs):
-        resource = '{class_name}s'.format(class_name=cls.__name__.lower())
+        resource = "{class_name}s".format(class_name=cls.__name__.lower())
         initial_results = cls._make_request(resource, **kwargs)
-        if initial_results.get('pagination', None):
-            return initial_results['pagination']['count']
+        if initial_results.get("pagination", None):
+            return initial_results["pagination"]["count"]
 
     @classmethod
     def _throttled_request(cls, url, params):
         response = None
         if not cls.ratelimit_remaining == 0:
             response = requests.get(url, params=params)
-            if 'x-ratelimit-remaining' in response.headers:
-                cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+            if "x-ratelimit-remaining" in response.headers:
+                cls.ratelimit_remaining = int(response.headers["x-ratelimit-remaining"])
             else:
                 cls.ratelimit_remaining = 1000
 
@@ -69,12 +69,14 @@ class PyOpenFecApiClass(object):
             while cls.ratelimit_remaining == 0 or response.status_code == 429:
                 cls.wait_time *= 1.5
                 logging.warn(
-                    'API rate limit exceeded. Waiting {}s.'.format(
-                        cls.wait_time))
+                    "API rate limit exceeded. Waiting {}s.".format(cls.wait_time)
+                )
                 time.sleep(cls.wait_time)
                 response = requests.get(url, params=params)
-                if 'x-ratelimit-remaining' in response.headers:
-                    cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                if "x-ratelimit-remaining" in response.headers:
+                    cls.ratelimit_remaining = int(
+                        response.headers["x-ratelimit-remaining"]
+                    )
                 elif response.status_code == 200:
                     cls.ratelimit_remaining = 120
                 else:
@@ -85,117 +87,122 @@ class PyOpenFecApiClass(object):
 
     @classmethod
     def fetch(cls, **kwargs):
-        raise NotImplementedError('fetch command implemented in subclasses only')
+        raise NotImplementedError("fetch command implemented in subclasses only")
 
     @classmethod
     def fetch_one(cls, **kwargs):
-        if 'resource' in kwargs:
-            resource = kwargs.pop('resource')
+        if "resource" in kwargs:
+            resource = kwargs.pop("resource")
         else:
-            resource = '%ss' % cls.__name__.lower()
+            resource = "%ss" % cls.__name__.lower()
         initial_results = cls._make_request(resource, **kwargs)
 
-        if initial_results.get('results', None):
-            if len(initial_results['results']) > 0:
-                first_result = initial_results['results'][0]
+        if initial_results.get("results", None):
+            if len(initial_results["results"]) > 0:
+                first_result = initial_results["results"][0]
                 return cls(**first_result)
         return None
 
     @classmethod
     def _make_request(cls, resource, **kwargs):
-        url = BASE_URL + VERSION + '/%s/' % resource
+        url = BASE_URL + VERSION + "/%s/" % resource
 
         if not API_KEY:
-            raise PyOpenFecException('Please export an env var OPENFEC_API_KEY with your API key.')
+            raise PyOpenFecException(
+                "Please export an env var OPENFEC_API_KEY with your API key."
+            )
 
         params = dict(kwargs)
-        params['api_key'] = API_KEY
+        params["api_key"] = API_KEY
 
         r = cls._throttled_request(url, params)
         logging.debug(r.url)
 
         if r.status_code != 200:
-            raise PyOpenFecException('OpenFEC site returned a status code of %s for this request.' % r.status_code)
+            raise PyOpenFecException(
+                "OpenFEC site returned a status code of %s for this request."
+                % r.status_code
+            )
 
         return r.json()
 
 
 class PyOpenFecApiPaginatedClass(PyOpenFecApiClass):
-
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' in kwargs:
-            resource = kwargs.pop('resource')
+        if "resource" in kwargs:
+            resource = kwargs.pop("resource")
         else:
-            resource = '%ss' % cls.__name__.lower()
+            resource = "%ss" % cls.__name__.lower()
         initial_results = cls._make_request(resource, **kwargs)
 
-        if initial_results.get('results', None):
-            if len(initial_results['results']) > 0:
-                for result in initial_results['results']:
+        if initial_results.get("results", None):
+            if len(initial_results["results"]) > 0:
+                for result in initial_results["results"]:
                     yield cls(**result)
 
-        if initial_results.get('pagination', None):
-            if initial_results['pagination'].get('pages', None):
-                if initial_results['pagination']['pages'] > 1:
+        if initial_results.get("pagination", None):
+            if initial_results["pagination"].get("pages", None):
+                if initial_results["pagination"]["pages"] > 1:
                     current_page = 2
 
-                    while current_page <= initial_results['pagination']['pages']:
+                    while current_page <= initial_results["pagination"]["pages"]:
                         params = dict(kwargs)
-                        params['page'] = current_page
+                        params["page"] = current_page
                         paged_results = cls._make_request(resource, **params)
 
-                        if paged_results.get('results', None):
-                            if len(paged_results['results']) > 0:
-                                for result in paged_results['results']:
+                        if paged_results.get("results", None):
+                            if len(paged_results["results"]) > 0:
+                                for result in paged_results["results"]:
                                     yield cls(**result)
 
                         current_page += 1
 
 
 class PyOpenFecApiIndexedClass(PyOpenFecApiClass):
-
     @classmethod
     def fetch(cls, **kwargs):
-        if 'resource' in kwargs:
-            resource = kwargs.pop('resource')
+        if "resource" in kwargs:
+            resource = kwargs.pop("resource")
         else:
-            resource = '%ss' % cls.__name__.lower()
+            resource = "%ss" % cls.__name__.lower()
         initial_results = cls._make_request(resource, **kwargs)
 
-        if initial_results.get('results', None):
-            if len(initial_results['results']) > 0:
-                for result in initial_results['results']:
+        if initial_results.get("results", None):
+            if len(initial_results["results"]) > 0:
+                for result in initial_results["results"]:
                     yield cls(**result)
 
-        if initial_results.get('pagination', None):
-            if initial_results['pagination'].get('pages', None):
-                if initial_results['pagination']['pages'] > 1:
-                    last_index = initial_results['pagination']['last_indexes']['last_index']
+        if initial_results.get("pagination", None):
+            if initial_results["pagination"].get("pages", None):
+                if initial_results["pagination"]["pages"] > 1:
+                    last_index = initial_results["pagination"]["last_indexes"][
+                        "last_index"
+                    ]
 
                     while last_index is not None:
                         params = dict(kwargs)
-                        params['last_index'] = int(last_index)
+                        params["last_index"] = int(last_index)
                         indexed_results = cls._make_request(resource, **params)
 
-                        if indexed_results.get('results', None):
-                            if len(indexed_results['results']) > 0:
-                                for result in indexed_results['results']:
+                        if indexed_results.get("results", None):
+                            if len(indexed_results["results"]) > 0:
+                                for result in indexed_results["results"]:
                                     yield cls(**result)
-                            last_index = indexed_results['pagination']['last_indexes']['last_index']
+                            last_index = indexed_results["pagination"]["last_indexes"][
+                                "last_index"
+                            ]
                         else:
                             last_index = None
 
 
 class SearchMixin(object):
-
     @classmethod
     def search(cls, querystring):
-        resource = 'names/%ss' % cls.__name__.lower()
-        search_result = cls._make_request(**{"resource": resource,
-                                             "q": querystring})
-        identifiers = [r['id'] for r in search_result['results']]
-        identifier_field = '{c}_id'.format(c=cls.__name__.lower())
+        resource = "names/%ss" % cls.__name__.lower()
+        search_result = cls._make_request(**{"resource": resource, "q": querystring})
+        identifiers = [r["id"] for r in search_result["results"]]
+        identifier_field = "{c}_id".format(c=cls.__name__.lower())
         for o in cls.fetch(**{identifier_field: identifiers}):
             yield o
 
@@ -206,6 +213,7 @@ def default_empty_list(func):
             return func(*args, **kwargs)
         except TypeError:
             return []
+
     return inner
 
 


### PR DESCRIPTION
Removing python2.7 support.

Python2.7 will be deprecated in 1 month, and I'm not able to provide the support to maintain backwards compatibility afterwards. Removing the unicode methods makes working in python3 debuggers less noisy, and encourages development in a stable, supported python version.

I attempted to keep these PRs separate, but my auto-linter formats these files upon save, and the size of the PR kept it reasonably reviewable even with those changes. This converts the full code base over the python black formatting, so formatting issues won't be present going forward.

**Changes**
- Styling according to Python black
- Removing `unicode` methods from objects