### PR TITLE
Increasing line length from 80 to 120

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,5 +4,8 @@
 # will need to generate wheels for each Python version that you support.
 universal=1
 
+[flake8]
+max-line-length = 120
+
 [metadata]
 description-file = README.md


### PR DESCRIPTION
Adding a param into `setup.cfg` to make linters aware that 120 characters is an acceptable line length.

The code base uses over 120 characters per line in several places, which is fine as far as legibility is concerned, so this PR makes the setup.cfg flake8 settings reflect that.