### PR TITLE
some suggestions for the package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,22 +6,25 @@ description = "OpenFEC API Client"
 license = "MIT"
 readme = "README.md"
 
-homepage = "https://github.com/jeremyjbowers/pyopenfec"
+homepage = "https://github.com/RobertTownley/pyopenfec"
 keywords = [
   "fec",
   "campaign",
   "finance",
   "openfec",
 ]
-repository = "https://github.com/jeremyjbowers/pyopenfec"
-
+repository = "https://github.com/RobertTownley/pyopenfec"
 
 authors = [
   "Jeremy Bowers <jeremyjbowers@gmail.com>",
   "Bob Lannon",
   "Kevin Schaul",
   "Janak Mayer",
-  "Evan Sonderegger",
+  "Evan Sonderegger <evan@rpy.xyz>",
+  "Robert Townley <me@roberttownley.com>",
+]
+
+maintainers = [
   "Robert Townley <me@roberttownley.com>",
 ]
 


### PR DESCRIPTION
Hi Robert!

I'm excited to see that this project continues to be useful at NJ and that it's now available via pip. Some suggestions with respect to packaging...

When I went to https://pypi.org/project/pyopenfec I noticed that the "Project links" and "GitHub statistics" sections link to the original repo from which this was forked. It occurred to me that that could be confusing to someone arriving at the PyPI page. They might follow those links and not realize that the code they downloaded via `pip install` came from a different place.

I also thought it should be made clear that you're the maintainer of this library now. It looks like the `maintainers` section of the `pyproject.toml` file is a [relatively recent addition](https://github.com/sdispater/poetry/pull/1175)

Please let me know if there's anything I can do to help!